### PR TITLE
fix(FEC-7533): BufferUnderrun event not fired during throttling

### DIFF
--- a/src/youbora-adapter.js
+++ b/src/youbora-adapter.js
@@ -131,7 +131,9 @@ $YB.plugins.KalturaV3.prototype.registerListeners = function () {
 
   // video seek start
   this.player.addEventListener(Event.SEEKING, function () {
-    context.seekingHandler();
+    if (!context.viewManager.isBuffering) {
+      context.seekingHandler();
+    }
   });
 
   // video seek end


### PR DESCRIPTION
### Description of the Changes

as hls.js does seek once buffer end Youbora should ignore this 'seeking' event.
this change (also done in v2 by Jordi https://github.com/kaltura/mwEmbed/blob/77d1d90c370813dd553f11a4f5f3ce53ce1c8a87/modules/Youbora/resources/youbora-plugin.js#L164) 
means Youbora ignores also explicit seeking during buffering

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
