### PR TITLE
fix(FEC-8361): plugins config is not updated

### DIFF
--- a/src/youbora-adapter.js
+++ b/src/youbora-adapter.js
@@ -26,6 +26,10 @@ $YB.plugins.KalturaV3 = function (player, options) {
 /** Inherit from generic plugin */
 $YB.plugins.KalturaV3.prototype = new $YB.plugins.Generic;
 
+$YB.plugins.KalturaV3.prototype.updateConfig = function (config) {
+  this.config = config;
+};
+
 $YB.plugins.KalturaV3.bindLogger = function (logger) {
   $YB.error = logger.error.bind(logger);
   $YB.notice = logger.info.bind(logger);

--- a/src/youbora.js
+++ b/src/youbora.js
@@ -49,7 +49,8 @@ export default class Youbora extends BasePlugin {
    */
   updateConfig(update: Object): void {
     super.updateConfig(update);
-    this._youbora.setOptions(update.options);
+    this._youbora.setOptions(this.config.options);
+    this._youbora.updateConfig(this.config);
     this._addPlayerMetadata();
   }
 


### PR DESCRIPTION
### Description of the Changes

Add missing method to update the Youbora SDK Kaltura plugin config.
The current handler didn't set it on `updateConfig` life cycle hook.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
