### PR TITLE
fix(FEC-8190): stop tracking on critical error

### DIFF
--- a/src/youbora-adapter.js
+++ b/src/youbora-adapter.js
@@ -128,6 +128,7 @@ $YB.plugins.KalturaV3.prototype.registerListeners = function () {
   this.player.addEventListener(Event.ERROR, function (error) {
     if (error.payload.severity === Error.Severity.CRITICAL){
       context.errorHandler(error.payload.code, error.payload.data);
+      context.endedHandler();
     }
   });
 


### PR DESCRIPTION
### Description of the Changes

call endedHandler on critical error to stop plugin from keep sending pings and events

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
