### PR TITLE
fix(FEC-8460): Duration parameter in 'start' request equals 0

### DIFF
--- a/src/youbora-adapter.js
+++ b/src/youbora-adapter.js
@@ -99,60 +99,68 @@ $YB.plugins.KalturaV3.prototype.getIsLive = function() {
  * @returns {void}
  */
 $YB.plugins.KalturaV3.prototype.registerListeners = function() {
-  // save context
-  let context = this;
   let Event = this.player.Event;
   let State = this.player.State;
 
   // Play is clicked (/start)
-  this.player.addEventListener(Event.PLAY, function() {
-    context.playHandler();
+  this.player.addEventListener(Event.PLAY, () => {
+    isMetadataLoaded().then(() => {
+      this.playHandler();
+    });
   });
 
   // video ends (stop)
-  this.player.addEventListener(Event.ENDED, function() {
-    context.endedHandler();
+  this.player.addEventListener(Event.ENDED, () => {
+    this.endedHandler();
   });
 
-  this.player.addEventListener(Event.PLAYING, function() {
-    context.playingHandler();
+  this.player.addEventListener(Event.PLAYING, () => {
+    this.playingHandler();
   });
 
   // Video pauses (pause)
-  this.player.addEventListener(Event.PAUSE, function() {
-    context.pauseHandler();
+  this.player.addEventListener(Event.PAUSE, () => {
+    this.pauseHandler();
   });
 
   // video error (error)
-  this.player.addEventListener(Event.ERROR, function(error) {
+  this.player.addEventListener(Event.ERROR, error => {
     if (error.payload.severity === Error.Severity.CRITICAL) {
-      context.errorHandler(error.payload.code, error.payload.data);
-      context.endedHandler();
+      this.errorHandler(error.payload.code, error.payload.data);
+      this.endedHandler();
     }
   });
 
   // video seek start
-  this.player.addEventListener(Event.SEEKING, function() {
+  this.player.addEventListener(Event.SEEKING, () => {
     if (!context.viewManager.isBuffering) {
-      context.seekingHandler();
+      this.seekingHandler();
     }
   });
 
   // video seek end
-  this.player.addEventListener(Event.SEEKED, function() {
-    context.seekedHandler();
+  this.player.addEventListener(Event.SEEKED, () => {
+    this.seekedHandler();
   });
 
-  this.player.addEventListener(Event.PLAYER_STATE_CHANGED, function(e) {
+  this.player.addEventListener(Event.PLAYER_STATE_CHANGED, e => {
     let newState = e.payload.newState.type;
     let oldState = e.payload.oldState.type;
     if (newState === State.BUFFERING) {
-      context.bufferingHandler();
+      this.bufferingHandler();
     }
     if (oldState === State.BUFFERING) {
-      context.bufferedHandler();
+      this.bufferedHandler();
     }
   });
+
+  const isMetadataLoaded = () => {
+    return new Promise(resolve => {
+      this.player.addEventListener(Event.LOADED_METADATA, () => {
+        return resolve();
+      });
+    });
+  };
 };
 
 module.exports = $YB.plugins.KalturaV3;


### PR DESCRIPTION
**dont review yet**

This happens because the metadata is not loaded to the video element yet.
I added a Promise which is resolved when loaded_metadata is fired from the player. 
so when we will send the start analytics after the promise is resolved.

*also changed the functions to arrow functions.

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
