### PR TITLE
fix(FEC-9651): enable using playkit-js-youbora with requireJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
     filename: '[name].js',
     library: ['KalturaPlayer', 'plugins', 'youbora'],
     libraryTarget: 'umd',
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './youbora/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
### Description of the Changes

In case a client uses requireJS,
umdNamedDefine will name the AMD module of the UMD build. Otherwise an anonymous define is used.

https://webpack.js.org/configuration/output/

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
