### PR TITLE
feat(FEC-10347): expose kaltura player as a global variable instead of UMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "flow-bin": "^0.129.0",
     "husky": "^4.2.5",
     "istanbul": "^0.4.5",
-    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v0.56.0",
+    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v1.0.0",
     "karma": "^5.1.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -104,7 +104,7 @@
   },
   "peerDependencies": {
     "@playkit-js/playkit-js": "0.63.0",
-    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v0.56.0"
+    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['KalturaPlayer', 'plugins', 'youbora'],
-    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './youbora/[resource-path]'
   },
   devtool: 'source-map',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['KalturaPlayer', 'plugins', 'youbora'],
-    libraryTarget: 'umd',
     umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './youbora/[resource-path]'
   },
@@ -59,11 +58,6 @@ module.exports = {
     modules: [path.resolve(__dirname, 'src'), 'node_modules']
   },
   externals: {
-    'kaltura-player-js': {
-      commonjs: 'kaltura-player-js',
-      commonjs2: 'kaltura-player-js',
-      amd: 'kaltura-player-js',
-      root: ['KalturaPlayer']
-    }
+    'kaltura-player-js': ['KalturaPlayer']
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,20 +876,20 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@playkit-js/playkit-js-dash@1.19.1":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.19.1.tgz#1b0e0b213c41b0ab63ea5e4eb8231b0f5a411f03"
-  integrity sha512-VL4EynMYnWW/I2fnHH+D0QLYBvwBXnkleG4yvfja0vLMEoP0o7BqdjunhMNwJP9/Zs+5+53r78NnZxsAHUZvMg==
+"@playkit-js/playkit-js-dash@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-dash/-/playkit-js-dash-1.20.1.tgz#2f1d99173a02ad04a0fe3104e418ee497c3778c7"
+  integrity sha512-gD/Jo2xOFIV+F62JcaWYvpHHnBbPkShhjxb1LoGAt/jxzM7dbSsjlTTXKFNKC3roAVNAsJMyeQ/S98H/QLw6sw==
 
-"@playkit-js/playkit-js-hls@1.20.0":
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.20.0.tgz#b6bcda5ab988c5931addabc729898c4b9ae3e801"
-  integrity sha512-4qBz0V7ftoNf5MO42/EyAFE2faDS6F3ofCoKJVLIiXj6UyMAN9qQJ/ErWBrZtJ1oxHJeDbpDfS/gfSPIHW/p/g==
+"@playkit-js/playkit-js-hls@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.21.1.tgz#d2248f0359e6c81a214bf59f3fad87c2b0e01964"
+  integrity sha512-YyUc707B/6tW9FfKOkv+mSj3oOal8zgxXsFAio451bxAVMdquvqGGWF1wSh1DQv4Zb9RjkzeG/kRoWAstq8+rw==
 
-"@playkit-js/playkit-js-ui@0.58.1":
-  version "0.58.1"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.58.1.tgz#ba57f539feed8a29da86ecc19a2efa969387a3e3"
-  integrity sha512-AHndW6wr7M+C841/9w6Ug2Q2ZrWL/JdayVnadRSmtF48BakvIR+S9P1MwKhOJc1TtOjZV4UoAMrS5p9sK6NW0g==
+"@playkit-js/playkit-js-ui@0.59.1":
+  version "0.59.1"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-ui/-/playkit-js-ui-0.59.1.tgz#47d8a5011ccd8832af48ee9b71a1c55e59d4d930"
+  integrity sha512-WqMDabFVvST7PJc54DN8otjMhVGTtlU9Vz69/NcTJj1/nEm2hrN7XfWkIzCs8/4H+1d8VrNN8XbjQvY9Q+IU8g==
   dependencies:
     js-logger "^1.6.0"
     preact "^10.3.4"
@@ -901,6 +901,14 @@
   version "0.63.0"
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.63.0.tgz#01c073dc2067befe57cdca168ea54b8583e07a30"
   integrity sha512-nJejwY2HQGk/imgqtkma79KOII4F2LIYm5E2irUJHv/8luflCuBwsihX/jD1H+kdkXvB5GjT9v2LHHHbfcj6Sg==
+  dependencies:
+    js-logger "^1.6.0"
+    ua-parser-js "^0.7.21"
+
+"@playkit-js/playkit-js@0.64.1":
+  version "0.64.1"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.64.1.tgz#12c8c12edd0cbe9ad2b0ac77a2fea2d32108a6e8"
+  integrity sha512-uvZKQd4DdaILt50O3gbVBTeeowZCXDObN6ydryFru4meDRpxlzmNgFQVuq7+IwJhDaczknT+3QNyqODMYpKiOA==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"
@@ -3375,15 +3383,15 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
-
 eventemitter3@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+
+eventemitter3@^4.0.3:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@^3.0.0:
   version "3.1.0"
@@ -4194,12 +4202,12 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@^0.13.1:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.13.2.tgz#3e7dd28e3787c69c6aba42b64b11eb2c3c8c29f1"
-  integrity sha512-sIg2t4uGpWQLzuK1Iid9614WOKqxj4OYg+EbFbhhTDCsxpENBN+Du3yBFnoi+a83DuOOHdiQd1ydnti9loSGXw==
+hls.js@^0.14.9:
+  version "0.14.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.14.11.tgz#b3d123c45b1feb8c5c19f70574074fa0a77e016b"
+  integrity sha512-l7fm8AAEIIVc9r+RZbVAPcpccWIk6oludZ7R78B/ZJsYvuL5LJF8h0o8iayoIcbPT8ArM8vBhOkWFbe9q46Kew==
   dependencies:
-    eventemitter3 "3.1.0"
+    eventemitter3 "^4.0.3"
     url-toolkit "^2.1.6"
 
 hmac-drbg@^1.0.0:
@@ -4998,20 +5006,20 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.0.tgz#7278a4027d889601640ee0ce0e5a00b992467da4"
   integrity sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
 
-"kaltura-player-js@https://github.com/kaltura/kaltura-player-js.git#v0.56.0":
-  version "0.56.0"
-  resolved "https://github.com/kaltura/kaltura-player-js.git#113d711eefa7032621eebf9f6b5c7b31737bf16c"
+"kaltura-player-js@https://github.com/kaltura/kaltura-player-js.git#v1.0.0":
+  version "1.0.0"
+  resolved "https://github.com/kaltura/kaltura-player-js.git#f023a921ee96af267dccce19318f3194588cafd3"
   dependencies:
     "@babel/polyfill" "^7.0.0"
-    "@playkit-js/playkit-js" "0.63.0"
-    "@playkit-js/playkit-js-dash" "1.19.1"
-    "@playkit-js/playkit-js-hls" "1.20.0"
-    "@playkit-js/playkit-js-ui" "0.58.1"
-    hls.js "^0.13.1"
+    "@playkit-js/playkit-js" "0.64.1"
+    "@playkit-js/playkit-js-dash" "1.20.1"
+    "@playkit-js/playkit-js-hls" "1.21.1"
+    "@playkit-js/playkit-js-ui" "0.59.1"
+    hls.js "^0.14.9"
     js-logger "^1.6.0"
-    playkit-js-providers "https://github.com/kaltura/playkit-js-providers.git#v2.22.0"
+    playkit-js-providers "https://github.com/kaltura/playkit-js-providers.git#v2.22.1"
     proxy-polyfill "^0.3.0"
-    shaka-player "2.5.13"
+    shaka-player "^3.0.4"
 
 karma-chai@^0.1.0:
   version "0.1.0"
@@ -6509,9 +6517,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-"playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#v2.22.0":
-  version "2.22.0"
-  resolved "https://github.com/kaltura/playkit-js-providers.git#bf485afe2f71e8ddf6949ee70d94d2f1045527f5"
+"playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#v2.22.1":
+  version "2.22.1"
+  resolved "https://github.com/kaltura/playkit-js-providers.git#d101e60d195056df5c8c54599d4baa458f29a4e9"
   dependencies:
     js-logger "^1.6.0"
 
@@ -7342,10 +7350,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@2.5.13:
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.13.tgz#f8c493b825c735fc86d619cba8b2eb2f2a382233"
-  integrity sha512-rEh7juGlTvvF10oD7+EukS12EysZXI2fiGvNLqO7GsBQ5R/sFwcTGEB8A6lWlHQXeGVbT+MxZWKMZwFE805G6A==
+shaka-player@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.4.tgz#241245f4019b3550ef58d6f83b8fc75c66ab8816"
+  integrity sha512-sjmArz8ukKNx5SU2O99kdJr1Z3TyDRn/p11ivUm/67jptCgYuIGI8swfvkJO5KD7MBJSaBP6z32D38dBx5AAxA==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
### Description of the Changes

set `libraryTarget:'var'` as default.
Change the externals to use the root only.

BREAKING CHANGE: This package is not UMD anymore

Solves FEC-10347

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
