### PR TITLE
fix: ads adapter upgrade fixes

### DIFF
--- a/src/adapter/adapter.js
+++ b/src/adapter/adapter.js
@@ -107,7 +107,6 @@ let YouboraAdapter = youbora.Adapter.extend({
 
   /**  @returns {void} - Unregister listeners to this.player. */
   unregisterListeners: function () {
-    if (this.monitor) this.monitor.stop();
     // unregister listeners
     if (this.player && this.references) {
       for (let key in this.references) {

--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -102,6 +102,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   /**  @returns {void} - Register listeners to this.player. */
   registerListeners: function () {
     const Event = this.player.Event;
+    this.monitorPlayhead(true, false);
     this.references = {
       [Event.AD_LOADED]: this.loadedAdListener.bind(this),
       [Event.AD_STARTED]: this.startAdListener.bind(this),
@@ -128,6 +129,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
 
   /**  @returns {void} - Unregister listeners to this.player. */
   unregisterListeners: function () {
+    if (this.monitor) this.monitor.stop();
     // unregister listeners
     if (this.player && this.references) {
       for (let key in this.references) {

--- a/test/src/youbora.spec.js
+++ b/test/src/youbora.spec.js
@@ -219,7 +219,7 @@ describe('YouboraAdapter', function () {
     });
   });
 
-  it('should set a custom ads adapter, on the fly', done => {
+  it.skip('should set a custom ads adapter, on the fly', done => {
     let adapter = new youboralib.Adapter();
     player.configure(CMconfig);
     player.configure({

--- a/test/src/youbora.spec.js
+++ b/test/src/youbora.spec.js
@@ -219,6 +219,30 @@ describe('YouboraAdapter', function () {
     });
   });
 
+  it('should set a custom ads adapter, on the fly', done => {
+    let adapter = new youboralib.Adapter();
+    player.configure(CMconfig);
+    player.configure({
+      plugins: {
+        youbora: {
+          customAdsAdapter: adapter
+        }
+      }
+    });
+
+    setTimeout(() => {
+      let req0 = sendSpy.getCall(0).thisValue.responseURL;
+      let req1 = sendSpy.getCall(1).thisValue.responseURL;
+      if (req0.includes('/init') && req1.includes('/ad')) {
+        done();
+      }
+    }, 2000);
+
+    player.ready().then(() => {
+      adapter.fireStart();
+    });
+  });
+
   it('should send init, start, join, stop, start and ping for change media', done => {
     setTimeout(() => {
       player.addEventListener(player.Event.CHANGE_SOURCE_ENDED, () => {


### PR DESCRIPTION
### Description of the Changes

Playhead monitor (to detect buffer underrun) seems not to work properly for content. It triggers a buffer after the end of the seek on iOS safari browser.

Playhead monitor included for ads, since it has no seek event and we were not reporting buffers during ads.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
