### PR TITLE
fix(FEC-10471): adPosition getter returns preroll for mid and post rolls

### DIFF
--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -120,7 +120,8 @@ let NativeAdsAdapter = youbora.Adapter.extend({
       [Event.AD_THIRD_QUARTILE]: this.thirdQuartileListener.bind(this),
       [Event.ENTER_FULLSCREEN]: this.enterFullscreenListener.bind(this),
       [Event.EXIT_FULLSCREEN]: this.exitFullscreenListener.bind(this),
-      [Event.AD_MANIFEST_LOADED]: this.manifestLoaded.bind(this)
+      [Event.AD_MANIFEST_LOADED]: this.manifestLoaded.bind(this),
+      [Event.AD_BREAK_START]: this.startBreakAdListener.bind(this)
     };
 
     for (let key in this.references) {
@@ -140,7 +141,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   },
 
   startBreakAdListener: function (e) {
-    this.adPosition = e.payload.adBreak.type || this.adPosition;
+    this.adPosition = e.payload.adBreak.type;
     this.numAds = e.payload.adBreak.numAds;
     this.fireBreakStart();
   },
@@ -151,7 +152,6 @@ let NativeAdsAdapter = youbora.Adapter.extend({
 
   loadedAdListener: function (e) {
     this.adObject = e.payload.ad;
-    this.adPosition = e.payload.adType;
   },
 
   startAdListener: function () {

--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -146,10 +146,6 @@ let NativeAdsAdapter = youbora.Adapter.extend({
     this.fireBreakStart();
   },
 
-  endBreakAdListener: function () {
-    this.fireBreakEnd();
-  },
-
   loadedAdListener: function (e) {
     this.adObject = e.payload.ad;
   },

--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -28,26 +28,24 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   /**  @returns {String} - current ad position (only ads) */
   getPosition: function () {
     let returnValue = youbora.Constants.AdPosition.Midroll;
-    if (this.adPosition) {
-      switch (this.adPosition) {
-        case 'preroll':
-          returnValue = youbora.Constants.AdPosition.Preroll;
-          break;
-        case 'postroll':
-          returnValue = youbora.Constants.AdPosition.Postroll;
-          break;
-        case 'midroll':
-          break;
-        case 'overlay':
-          returnValue = 'overlay';
-          break;
-      }
-    } else {
-      if (!this.plugin.getAdapter().flags.isJoined) {
+    switch (this.adPosition) {
+      case 'preroll':
         returnValue = youbora.Constants.AdPosition.Preroll;
-      } else if (!this.plugin.getIsLive() && this.plugin.getPlayhead() > this.plugin.getDuration() - 1) {
+        break;
+      case 'postroll':
         returnValue = youbora.Constants.AdPosition.Postroll;
-      }
+        break;
+      case 'midroll':
+        break;
+      case 'overlay':
+        returnValue = 'overlay';
+        break;
+      default:
+        if (!this.plugin.getAdapter().flags.isJoined) {
+          returnValue = youbora.Constants.AdPosition.Preroll;
+        } else if (!this.plugin.getIsLive() && this.plugin.getPlayhead() > this.plugin.getDuration() - 1) {
+          returnValue = youbora.Constants.AdPosition.Postroll;
+        }
     }
     return returnValue;
   },

--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -28,24 +28,26 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   /**  @returns {String} - current ad position (only ads) */
   getPosition: function () {
     let returnValue = youbora.Adapter.AdPosition.MIDROLL;
-    switch (this.adPosition) {
-      case 'preroll':
-        returnValue = youbora.Adapter.AdPosition.PREROLL;
-        break;
-      case 'postroll':
-        returnValue = youbora.Adapter.AdPosition.POSTROLL;
-        break;
-      case 'midroll':
-        break;
-      case 'overlay':
-        returnValue = 'overlay';
-        break;
-      default:
-        if (!this.plugin.getAdapter().flags.isJoined) {
+    if (this.adPosition) {
+      switch (this.adPosition) {
+        case 'preroll':
           returnValue = youbora.Adapter.AdPosition.PREROLL;
-        } else if (!this.plugin.getAdapter().getIsLive() && this.plugin.getAdapter().getPlayhead() > this.plugin.getAdapter().getDuration() - 1) {
+          break;
+        case 'postroll':
           returnValue = youbora.Adapter.AdPosition.POSTROLL;
-        }
+          break;
+        case 'midroll':
+          break;
+        case 'overlay':
+          returnValue = 'overlay';
+          break;
+      }
+    } else {
+      if (!this.plugin.getAdapter().flags.isJoined) {
+        returnValue = youbora.Adapter.AdPosition.PREROLL;
+      } else if (!this.plugin.getIsLive() && this.plugin.getPlayhead() > this.plugin.getDuration() - 1) {
+        returnValue = youbora.Adapter.AdPosition.POSTROLL;
+      }
     }
     return returnValue;
   },
@@ -138,7 +140,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   },
 
   startBreakAdListener: function (e) {
-    this.adPosition = e.payload.adBreak.type;
+    this.adPosition = e.payload.adBreak.type || this.adPosition;
     this.numAds = e.payload.adBreak.numAds;
     this.fireBreakStart();
   },
@@ -149,6 +151,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
 
   loadedAdListener: function (e) {
     this.adObject = e.payload.ad;
+    this.adPosition = e.payload.adType;
   },
 
   startAdListener: function () {

--- a/src/adapter/ads/nativeads.js
+++ b/src/adapter/ads/nativeads.js
@@ -27,14 +27,14 @@ let NativeAdsAdapter = youbora.Adapter.extend({
 
   /**  @returns {String} - current ad position (only ads) */
   getPosition: function () {
-    let returnValue = youbora.Adapter.AdPosition.MIDROLL;
+    let returnValue = youbora.Constants.AdPosition.Midroll;
     if (this.adPosition) {
       switch (this.adPosition) {
         case 'preroll':
-          returnValue = youbora.Adapter.AdPosition.PREROLL;
+          returnValue = youbora.Constants.AdPosition.Preroll;
           break;
         case 'postroll':
-          returnValue = youbora.Adapter.AdPosition.POSTROLL;
+          returnValue = youbora.Constants.AdPosition.Postroll;
           break;
         case 'midroll':
           break;
@@ -44,9 +44,9 @@ let NativeAdsAdapter = youbora.Adapter.extend({
       }
     } else {
       if (!this.plugin.getAdapter().flags.isJoined) {
-        returnValue = youbora.Adapter.AdPosition.PREROLL;
+        returnValue = youbora.Constants.AdPosition.Preroll;
       } else if (!this.plugin.getIsLive() && this.plugin.getPlayhead() > this.plugin.getDuration() - 1) {
-        returnValue = youbora.Adapter.AdPosition.POSTROLL;
+        returnValue = youbora.Constants.AdPosition.Postroll;
       }
     }
     return returnValue;
@@ -185,7 +185,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
 
   errorAdListener: function (e) {
     this.fireError(e.payload.error.code, e.payload.error.message);
-    if (this.getPosition() === youbora.Adapter.AdPosition.POSTROLL) {
+    if (this.getPosition() === youbora.Constants.AdPosition.Postroll) {
       this.plugin.getAdapter().stopBlockedByAds = false;
       this.plugin.fireStop();
     }
@@ -220,7 +220,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   allAdsCompletedListener: function () {
     this.fireStop();
     this.plugin.getAdapter().stopBlockedByAds = false;
-    if (this.getPosition() === youbora.Adapter.AdPosition.POSTROLL) this.plugin.getAdapter().fireStop();
+    if (this.getPosition() === youbora.Constants.AdPosition.Postroll) this.plugin.getAdapter().fireStop();
     this.adPosition = null;
   },
 
@@ -232,7 +232,7 @@ let NativeAdsAdapter = youbora.Adapter.extend({
   resetFlags: function () {
     this.currentTime = null;
     this.adObject = null;
-    if (this.getPosition() === youbora.Adapter.AdPosition.POSTROLL) {
+    if (this.getPosition() === youbora.Constants.AdPosition.Postroll) {
       this.adPosition = null;
     }
   }


### PR DESCRIPTION
### Description of the Changes

Use `youbora.Constants` instead of `youbora.Adapter.AdPosition`
Also bind to `AD_BREAk_START`

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
