### PR TITLE
fix(FEC-12059): [Youbora] Rendition values have a high number of "Undefined data" records

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -15,7 +15,9 @@
       }],
       'plugins': {
         'youbora': {
-          accountCode: 'powerdev'
+          options: {
+            accountCode: 'powerdev'
+          }
         }
       }
     });

--- a/src/adapter/adapter.js
+++ b/src/adapter/adapter.js
@@ -52,10 +52,9 @@ let YouboraAdapter = youbora.Adapter.extend({
   getRendition: function () {
     let activeVideo = this.player.getActiveTracks().video;
     if (activeVideo) {
-      if (isNaN(activeVideo.bandwidth)) {
-        return null;
-      }
-      return youbora.Util.buildRenditionString(activeVideo.width, activeVideo.height, activeVideo.bandwidth);
+      const videoWidth = activeVideo.width || this.player.videoWidth;
+      const videoHeight = activeVideo.height || this.player.videoHeight;
+      return youbora.Util.buildRenditionString(videoWidth, videoHeight, activeVideo.bandwidth);
     }
     return null;
   },

--- a/src/index.html
+++ b/src/index.html
@@ -3,32 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <title>Title</title>
+  <script src="https://cdnapisec.kaltura.com/p/2215841/embedPlaykitJs/uiconf_id/42237501/"></script>
   <script src="./playkit-youbora.js"></script>
 </head>
 <body>
-<div id="player-placeholder"></div>
+<div id="player-placeholder" style="width: 640px; height: 360px;"></div>
 <script>
-  window.p = Playkit.loadPlayer('player-placeholder', {
-    sources: {
-      "progressive": [
-        {
-          "url": "http://deslasexta.antena3.com/mp_series1/2012/09/10/00001.mp4",
-          "mimetype": "video/mp4",
-          "id": "id1",
-          "width": 200,
-          "height": 100,
-          "bandwidth": 100000,
-          "label": "label1"
-        }
-      ]
+  const config = {
+    logLevel: "DEBUG",
+    targetId: "player-placeholder",
+    provider: {
+      partnerId: "2215841"
     },
     plugins: {
       youbora: {
-        'accountCode': 'powerdev'
+        options: {
+          'accountCode': "kalturatest",
+          'user.name': 'yoni'
+        }
       }
     }
-  });
-  window.p.play();
+  }
+
+  const player = KalturaPlayer.setup(config);
+  player.loadMedia({entryId: "1_ebs5e9cy"});
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Description of the Changes

issue: Safari doesn’t expose the videoTrack.height/width/bandwidth so youbora doesn;t send the rendition
fix: Expose the native element.videoHeight and element.videoWidth on Kaltura-player.js and take the values from there

solves:  FEC-12059

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated