### PR TITLE
fix(FEC-12952): Image and Youbora integration

### DIFF
--- a/src/adapter/adapter.js
+++ b/src/adapter/adapter.js
@@ -155,6 +155,7 @@ let YouboraAdapter = youbora.Adapter.extend({
 
   /** @returns {void} - Listener for 'load_start' event. */
   loadListener: function () {
+    this.plugin.options['content.playbackType'] = MediaType.IMAGE;
     if (this.player.config.playback.preload !== 'auto') {
       this.playListener();
     }


### PR DESCRIPTION
### Description of the Changes

Add 'image' media type to Youbora Analytics 

solves: FEC-12952

related prs:
https://github.com/kaltura/playkit-js-image-player/pull/5
https://github.com/kaltura/playkit-js/pull/702

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
